### PR TITLE
Refactor docker-machine calls

### DIFF
--- a/executors/docker/machine/consts.go
+++ b/executors/docker/machine/consts.go
@@ -3,3 +3,6 @@ package machine
 import "time"
 
 var provisionRetryInterval = time.Second
+var removalRetryInterval = time.Minute
+var useMachineRetries = 10
+var useMachineRetryInterval = 10 * time.Second

--- a/executors/docker/machine/details.go
+++ b/executors/docker/machine/details.go
@@ -8,15 +8,17 @@ import (
 	"github.com/Sirupsen/logrus"
 
 	"gitlab.com/gitlab-org/gitlab-ci-multi-runner/helpers"
+	"gitlab.com/gitlab-org/gitlab-ci-multi-runner/helpers/docker"
 )
 
 type machineDetails struct {
-	Name      string
-	Created   time.Time `yaml:"-"`
-	Used      time.Time `yaml:"-"`
-	UsedCount int
-	State     machineState
-	Reason    string
+	Name        string
+	Created     time.Time `yaml:"-"`
+	Used        time.Time `yaml:"-"`
+	UsedCount   int
+	State       machineState
+	Reason      string
+	Credentials *docker_helpers.DockerCredentials
 }
 
 func (m *machineDetails) isUsed() bool {


### PR DESCRIPTION
This reduces number of API calls using docker-machine, since some of the data are cached.

- Use `Exist` instead of `CanConnect` when acquiring machine
- Cache `DockerCredentials` to not call it every time, just check the machine state with `CanConnect` (consumes one request per build)
- Refactor `Use` to unconditionally allocate machine if we can't connect to existing one